### PR TITLE
Only use linter and proper when building project locally

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,9 @@
 {deps, []}.
 
 {plugins, [
-    {rebar3_abnf_compiler, "0.1.3"},
+    {rebar3_abnf_compiler, "0.1.3"}]}.
+
+{project_plugins, [
     {rebar3_lint, "0.4.0"},
     {rebar3_proper, "0.12.1"}]}.
 


### PR DESCRIPTION
I'm finding when upgrading my application to OTP 27.0 that compilation is failing in GitHub Actions. Everything seems to work fine on my workstation.

The thing that fails to compile is a dependency of a dependency of `rebar3_lint`, so my thought is to switch the linter and property tester to be rebar3 `project_plugin`s rather than `plugin`s—so dependents of this library do not need to install them.